### PR TITLE
feat: watch playlists

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/soldiermoth/hlsq
 
 go 1.14
+
+require golang.org/x/text v0.3.4

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,3 @@
+golang.org/x/text v0.3.4 h1:0YWbFKbhXG/wIiuHDSKpS0Iy7FSA+u45VtBMfQcFTTc=
+golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
I don't know that this is necessarily the best way to do this, but something like this might be nice.

This would allow me to run `hlsq -watch -url https://path/to/some.m3u8` and still get colorful output.